### PR TITLE
Fixed a bug that a lot of textlint-ruby processes were booted when running textlint with --fix option.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## Next Version
+
+- #2 Fixed a bug that a lot of textlint-ruby processes were booted when running textlint with --fix option.
+
 ## [3.0.0]
 
 - The parsing process has been optimized. Currently, `textlint-ruby` starts up as a communication process and uses the process as long as you are using textlint.

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -88,15 +88,15 @@ export class Client {
     this._enqueuedShutdown = true;
 
     this._shutdownPromise = new Promise<void>((resolve) => {
-      const tryToShutdown = (): void => {
+      const tryToShutdown = (wait: number = 0): void => {
         setTimeout(() => {
           if (Object.keys(this._requests).length === 0) {
             this.shutdown();
             resolve();
           } else {
-            tryToShutdown();
+            tryToShutdown(10);
           }
-        }, 0);
+        }, wait);
       };
 
       tryToShutdown();

--- a/src/RubyProcessor.ts
+++ b/src/RubyProcessor.ts
@@ -16,8 +16,9 @@ const clientBuilder = ((): ClientBuilder => {
   return {
     shutdown: () => {
       if (client) {
-        client.enqueueShutdown();
-        client = undefined;
+        client.enqueueShutdown().then(() => {
+          client = undefined;
+        });
       }
     },
 


### PR DESCRIPTION
When postProcess was invoked, textlint-ruby processes were shutdown lazily, but since it was not designed to be invoked in parallel, the next new process was launched before the shutdown was completed.
In this change, the process of initializing cached variable after shutdown is delayed.